### PR TITLE
Replace golint with revive.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test:
 	go test -cover ./...
 
 lint:
-	golangci-lint run -E gofmt -E golint --exclude-use-default=false
+	golangci-lint run -E gofmt -E revive --exclude-use-default=false
 
 image:
 	$(eval image=$(shell ko publish --local . 2>/dev/null))


### PR DESCRIPTION
The golint tool is deprecated. Switch to the recommended replacement.

Fixes a warning in the default `make` output.